### PR TITLE
Enhance x-axis tick labels with dynamic formatting

### DIFF
--- a/studylocus/src/main.js
+++ b/studylocus/src/main.js
@@ -1796,7 +1796,29 @@ document.addEventListener("DOMContentLoaded", () => {
                             },
                             x: {
                                 grid: { display: false },
-                                ticks: { color: '#6b7280', font: { size: 10 } }
+                                ticks: {
+                                  color: "#6b7280",
+                                  font: { size: 10 },
+                                  callback: function (value, index) {
+                                    const label = this.getLabelForValue(index);
+
+                                    // Calculate available width per label
+                                    const chartWidth = this.chart.width;
+                                    const labelCount = this.chart.data.labels.length;
+                                    const avgCharWidth = 7; // ~7px per character at default font size
+                                    const maxChars = Math.floor(
+                                      chartWidth / labelCount / avgCharWidth,
+                                    );
+                
+                                    if (label.length <= maxChars) return label;
+                
+                                    // 3 from start + 3 from end, but only if space allows
+                                    const half = Math.floor((maxChars - 1) / 2); // -1 for the ellipsis
+                                    const start = Math.max(3, half);
+                                    const end = Math.max(3, maxChars - start);
+                
+                                    return label.slice(0, start) + "…" + label.slice(-end);
+                                },
                             },
                         },
                     },


### PR DESCRIPTION
Fixed x-axis label overflow on line graph.  Added a callback function to format x-axis ticks based on available width.
Labels now dynamically truncate to start…end format based on available chart width instead of shifting the entire graph sideways.

Before
<img width="1017" height="485" alt="image" src="https://github.com/user-attachments/assets/7be64b51-7fe9-4b23-a9dc-dbb4d842219f" />

After 
<img width="1008" height="534" alt="image" src="https://github.com/user-attachments/assets/80f05a62-8c1c-4fcd-ad2b-082d7819ad78" />
